### PR TITLE
Better current level handling

### DIFF
--- a/block/build/render.php
+++ b/block/build/render.php
@@ -2,10 +2,28 @@
 
 namespace HM\TOC;
 
+use WP_HTML_Tag_Processor;
+
 $post_id = isset( $attributes['postId'] ) ? $attributes['postId'] : ( $block->context['postId'] ?? null );
 $post = get_post( $post_id );
 
 if ( ! $post ) {
+	return;
+}
+
+$max_level = $attributes['maxLevel'] ?? 3;
+
+// Work out the current level by finding the heighest level heading within the content.
+// Typically this is H2. But technically it can be anything.
+foreach ( array_slice( [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ], 0, $max_level ) as $i => $heading_tag ) {
+	$tags = new WP_HTML_Tag_Processor( $post->post_content );
+	if ( $tags->next_tag( $heading_tag ) ) {
+		$current_level = $i + 1;
+		break;
+	}
+}
+
+if ( ! $current_level ) {
 	return;
 }
 
@@ -23,6 +41,5 @@ printf(
 );
 
 printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-table-of-contents' ) );
-the_heading_list( $hierarchy, $attributes['maxLevel'] ?? 3 );
-
+the_heading_list( $hierarchy, $max_level, $current_level );
 echo '</div>';

--- a/block/src/render.php
+++ b/block/src/render.php
@@ -2,10 +2,28 @@
 
 namespace HM\TOC;
 
+use WP_HTML_Tag_Processor;
+
 $post_id = isset( $attributes['postId'] ) ? $attributes['postId'] : ( $block->context['postId'] ?? null );
 $post = get_post( $post_id );
 
 if ( ! $post ) {
+	return;
+}
+
+$max_level = $attributes['maxLevel'] ?? 3;
+
+// Work out the current level by finding the heighest level heading within the content.
+// Typically this is H2. But technically it can be anything.
+foreach ( array_slice( [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ], 0, $max_level ) as $i => $heading_tag ) {
+	$tags = new WP_HTML_Tag_Processor( $post->post_content );
+	if ( $tags->next_tag( $heading_tag ) ) {
+		$current_level = $i + 1;
+		break;
+	}
+}
+
+if ( ! $current_level ) {
 	return;
 }
 
@@ -23,6 +41,5 @@ printf(
 );
 
 printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-table-of-contents' ) );
-the_heading_list( $hierarchy, $attributes['maxLevel'] ?? 3 );
-
+the_heading_list( $hierarchy, $max_level, $current_level );
 echo '</div>';


### PR DESCRIPTION
There is a problem with the way `maxLevel` is working right now - I have set it to "2" but I'm still seeing H3s. 

The reason for this is that the top level heading we get from `get_header_hierarchy` is h2. So in this case... we need to set current level to '2' in order for the maxLevel attribute to work correctly. 

I've built some functionality to check for the highest level tag in the content, and set the current level to this. 

