### PR TITLE
Update textdomain

### DIFF
--- a/block/build/render.php
+++ b/block/build/render.php
@@ -40,6 +40,6 @@ printf(
 	$wrapper_attributes, // @codingStandardsIgnoreLine WordPress.Security.EscapeOutput.OutputNotEscaped
 );
 
-printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-table-of-contents' ) );
+printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-toc' ) );
 the_heading_list( $hierarchy, $max_level, $current_level );
 echo '</div>';

--- a/block/src/index.js
+++ b/block/src/index.js
@@ -13,7 +13,7 @@ registerBlockType( metadata.name, {
 				<InspectorControls>
 					<PanelBody>
 						<SelectControl
-							label={ __( 'Maximum Header Depth', 'hm-table-of-contents' ) }
+							label={ __( 'Maximum Header Depth', 'hm-toc' ) }
 							value={ attributes.maxLevel || 3 }
 							options={ [
 								{ label: '1', value: 1 },

--- a/block/src/render.php
+++ b/block/src/render.php
@@ -40,6 +40,6 @@ printf(
 	$wrapper_attributes, // @codingStandardsIgnoreLine WordPress.Security.EscapeOutput.OutputNotEscaped
 );
 
-printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-table-of-contents' ) );
+printf( '<h2>%s</h2>', esc_html__( 'Table of contents', 'hm-toc' ) );
 the_heading_list( $hierarchy, $max_level, $current_level );
 echo '</div>';

--- a/plugin.php
+++ b/plugin.php
@@ -4,6 +4,7 @@
  * Description: Add anchors to headings in post content and generate table of contents.
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
+ * Text Domain: hm-toc
  * Version: 1.1.5
  */
 


### PR DESCRIPTION
We're not setting a textdomain correctly in the plugin header and it's causing some issues - if installed from packagist then 
the directory `hm-toc` is used. I think we should update all translations to use this and also specify this in the plugin header. 